### PR TITLE
Specify GO version 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ WB_DB_HOST=localhost:6379             // The Redis IP address with port
 WB_DB_PASSWORD=password               // The Redis password 
 ```
 ## Building
-* Set GOPATH env variable
+* Install go 1.5: `brew install https://raw.githubusercontent.com/Homebrew/homebrew-versions/master/go15.rb`
+* [Set GOPATH env variable](https://golang.org/pkg/go/build/)
 * Check out whiteboardbot project from github using go get: `go get github.com/pivotal-sydney/whiteboardbot`
 * Go to the project directory: `cd $GOPATH/src/github.com/pivotal-sydney/whiteboardbot/`
 * Install godep (for dependency managment): `go get github.com/tools/godep`


### PR DESCRIPTION
Specify GO version and provide context around how to set up the GOPATH env variable.

The app ran using the default homebrew install version of GO 1.6, but the tests failed with this output:

```
package github.com/pivotal-sydney/whiteboardbot/vendor/github.com/garyburd/redigo/redis
    imports github.com/garyburd/redigo/internal: use of internal package not allowed
package github.com/pivotal-sydney/whiteboardbot/vendor/github.com/onsi/ginkgo
    imports github.com/onsi/ginkgo/internal/codelocation: use of internal package not allowed
package github.com/pivotal-sydney/whiteboardbot/vendor/github.com/onsi/ginkgo
    imports github.com/onsi/ginkgo/internal/failer: use of internal package not allowed
package github.com/pivotal-sydney/whiteboardbot/vendor/github.com/onsi/ginkgo
    imports github.com/onsi/ginkgo/internal/remote: use of internal package not allowed
package github.com/pivotal-sydney/whiteboardbot/vendor/github.com/onsi/ginkgo
    imports github.com/onsi/ginkgo/internal/suite: use of internal package not allowed
package github.com/pivotal-sydney/whiteboardbot/vendor/github.com/onsi/ginkgo
    imports github.com/onsi/ginkgo/internal/testingtproxy: use of internal package not allowed
package github.com/pivotal-sydney/whiteboardbot/vendor/github.com/onsi/ginkgo
    imports github.com/onsi/ginkgo/internal/writer: use of internal package not allowed
package github.com/pivotal-sydney/whiteboardbot/vendor/github.com/onsi/gomega
    imports github.com/onsi/gomega/internal/assertion: use of internal package not allowed
package github.com/pivotal-sydney/whiteboardbot/vendor/github.com/onsi/gomega
    imports github.com/onsi/gomega/internal/asyncassertion: use of internal package not allowed
package github.com/pivotal-sydney/whiteboardbot/vendor/github.com/onsi/gomega
    imports github.com/onsi/gomega/internal/testingtsupport: use of internal package not allowed
```

Switching to go 1.5 solved the issue.
