### PR TITLE
A better story for deploying to Clound Foundry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 manifest.yml
+whiteboardbot

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-Godeps/_workspace/
+vendor/
 manifest.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Godeps/_workspace/
+manifest.yml

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,9 +1,7 @@
 {
 	"ImportPath": "github.com/pivotal-sydney/whiteboardbot",
-	"GoVersion": "go1.5",
-	"Packages": [
-		"./..."
-	],
+	"GoVersion": "go1.7",
+	"GodepVersion": "v74",
 	"Deps": [
 		{
 			"ImportPath": "github.com/garyburd/redigo/internal",
@@ -17,16 +15,6 @@
 			"ImportPath": "github.com/nlopes/slack",
 			"Comment": "v0.0.1-69-g9153359",
 			"Rev": "9153359e4c6e3dd6fecd68332164321b5efd543f"
-		},
-		{
-			"ImportPath": "github.com/onsi/ginkgo",
-			"Comment": "v1.2.0-29-g7f8ab55",
-			"Rev": "7f8ab55aaf3b86885aa55b762e803744d1674700"
-		},
-		{
-			"ImportPath": "github.com/onsi/gomega",
-			"Comment": "v1.0-71-g2152b45",
-			"Rev": "2152b45fa28a361beba9aab0885972323a444e28"
 		},
 		{
 			"ImportPath": "golang.org/x/net/websocket",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2,6 +2,9 @@
 	"ImportPath": "github.com/pivotal-sydney/whiteboardbot",
 	"GoVersion": "go1.7",
 	"GodepVersion": "v74",
+	"Packages": [
+		"./..."
+	],
 	"Deps": [
 		{
 			"ImportPath": "github.com/garyburd/redigo/internal",
@@ -17,8 +20,151 @@
 			"Rev": "9153359e4c6e3dd6fecd68332164321b5efd543f"
 		},
 		{
+			"ImportPath": "github.com/onsi/ginkgo",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/config",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/codelocation",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/containernode",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/failer",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/leafnodes",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/remote",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/spec",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/specrunner",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/suite",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/testingtproxy",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/internal/writer",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/reporters",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/reporters/stenographer",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/ginkgo/types",
+			"Comment": "v1.2.0-71-g7b6efc7",
+			"Rev": "7b6efc7d7b052568b49ac02d3141c9d7a5a494a4"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/format",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/internal/assertion",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/internal/asyncassertion",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/internal/oraclematcher",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/internal/testingtsupport",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/matchers",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/matchers/support/goraph/bipartitegraph",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/matchers/support/goraph/edge",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/matchers/support/goraph/node",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/matchers/support/goraph/util",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
+			"ImportPath": "github.com/onsi/gomega/types",
+			"Comment": "v1.0-122-gd59fa0a",
+			"Rev": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3"
+		},
+		{
 			"ImportPath": "golang.org/x/net/websocket",
 			"Rev": "cbbbe2bc0f2efdd2afb318d93f1eadb19350e4a3"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "30de6d19a3bd89a5f38ae4028e23aaa5582648af"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "31c299268d302dd0aa9a0dcf765a3d58971ac83f"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ WB_DB_PASSWORD=password               // The Redis password
 * Now you're ready to build the project: `go build` This will create a whiteboardbot binary which can be run from the command line.
 * To run the test execute this command: `go test ./...`
 
+## Deploying To Cloud Foundry
+* Set GOPATH env variable
+* Check out whiteboardbot project from github using go get: `go get github.com/pivotal-sydney/whiteboardbot`
+* Go to the project directory: `cd $GOPATH/src/github.com/pivotal-sydney/whiteboardbot/`
+* Install godep (for dependency managment): `go get github.com/tools/godep`
+* Fetch all dependencies using godep: `godep restore`
+* Update all dependencies using godep: `godep update ./...` (this creates the `vendor` dir)
+* Copy the sample manifest and fill it in with your details: `cp manifest.yml.sample manifest.yml`
+* Push the app using the Cloud Foundry CLI: `cf push`
+
 ## Add bot to Slack channel
 Once the bot is running, mention `@whiteboardbot` in a channel, and register a standup ID
 ```

--- a/app/app_suite_test.go
+++ b/app/app_suite_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestWhiteboardbot(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Model Suite")
+	RunSpecs(t, "App Suite")
 }

--- a/manifest.yml.example
+++ b/manifest.yml.example
@@ -1,5 +1,5 @@
 applications:
-  - name: whiteboardbot
+  - name: [your-app-name]
     memory: 64M
     instances: 1
     buildpack: https://github.com/cloudfoundry/go-buildpack.git


### PR DESCRIPTION
A few small changes to make it easier to deploy to Cloud Foundry:
- bump to Go 1.7 to avoid messing with `GO15VENDOREXPERIMENT` environment variables
- don't check in manifest.yml, provide a sample instead and ignore the actual
- add deploy instructions to the README

I'm not sure whether I'm doing the Godeps business right, though. I get everything building and passing with `Godeps.json` as in this branch, but it's considerably more verbose than [what was before](https://github.com/pivotal-sydney/whiteboardbot/blob/1f7c1424df1b079d35eb529df24a5be2eee8d7bf/Godeps/Godeps.json). Suggestions welcome!

**EDIT:** I just realized `circle.yml` has some deployment bits in it. Those might stop working with our move of `manifest.yml`.
